### PR TITLE
Add pretty format for boolean flags

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -4,6 +4,15 @@ load("//private:util.bzl", "ge", "lt")
 
 # buildifier: keep-sorted
 FLAGS = {
+    "build_runfile_links": struct(
+        default = False,
+        description = """\
+        Avoid creating a runfiles tree for binaries or tests until it is needed.
+        See https://github.com/bazelbuild/bazel/issues/6627
+        This may break local workflows that `build` a binary target, then run the resulting program outside of `bazel run`.
+        In those cases, the script will need to call `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
+        """,
+    ),
     "experimental_remote_cache_eviction_retries": struct(
         default = 5,
         if_bazel_version = ge("6.2.0") and lt("8.0.0rc1"),


### PR DESCRIPTION
Closes https://github.com/bazel-contrib/bazelrc-preset.bzl/issues/7

Adding `build_runfile_links` to demo how the new implementation works. I tooks the flag description from bazel-lib. I was not able to find when this flag was added, maybe it was always there 🤷 