### PR TITLE
chore: improve formatting

### DIFF
--- a/.github/workflows/delta.yaml
+++ b/.github/workflows/delta.yaml
@@ -24,6 +24,7 @@ jobs:
         run: |
           bazel build tests:preset
           cat bazel-bin/tests/preset.bazelrc | tee /tmp/new
+          git restore MODULE.bazel.lock
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
       - name: Prior output

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -126,7 +126,8 @@
     "https://bcr.bazel.build/modules/rules_python/0.40.0/MODULE.bazel": "9d1a3cd88ed7d8e39583d9ffe56ae8a244f67783ae89b60caafc9f5cf318ada7",
     "https://bcr.bazel.build/modules/rules_python/0.40.0/source.json": "939d4bd2e3110f27bfb360292986bb79fd8dcefb874358ccd6cdaa7bda029320",
     "https://bcr.bazel.build/modules/rules_shell/0.2.0/MODULE.bazel": "fda8a652ab3c7d8fee214de05e7a9916d8b28082234e8d2c0094505c5268ed3c",
-    "https://bcr.bazel.build/modules/rules_shell/0.2.0/source.json": "7f27af3c28037d9701487c4744b5448d26537cc66cdef0d8df7ae85411f8de95",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/MODULE.bazel": "de4402cd12f4cc8fda2354fce179fdb068c0b9ca1ec2d2b17b3e21b24c1a937b",
+    "https://bcr.bazel.build/modules/rules_shell/0.3.0/source.json": "c55ed591aa5009401ddf80ded9762ac32c358d2517ee7820be981e2de9756cf3",
     "https://bcr.bazel.build/modules/stardoc/0.5.1/MODULE.bazel": "1a05d92974d0c122f5ccf09291442580317cdd859f07a8655f1db9a60374f9f8",
     "https://bcr.bazel.build/modules/stardoc/0.5.3/MODULE.bazel": "c7f6948dae6999bf0db32c1858ae345f112cacf98f174c7a8bb707e41b974f1c",
     "https://bcr.bazel.build/modules/stardoc/0.5.6/MODULE.bazel": "c43dabc564990eeab55e25ed61c07a1aadafe9ece96a4efabb3f8bf9063b71ef",
@@ -141,70 +142,5 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {
-    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
-      "general": {
-        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
-        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
-        "recordedFileInputs": {},
-        "recordedDirentsInputs": {},
-        "envVariables": {},
-        "generatedRepoSpecs": {
-          "com_github_jetbrains_kotlin_git": {
-            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
-            "attributes": {
-              "urls": [
-                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
-              ],
-              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
-            }
-          },
-          "com_github_jetbrains_kotlin": {
-            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
-            "attributes": {
-              "git_repository_name": "com_github_jetbrains_kotlin_git",
-              "compiler_version": "1.9.23"
-            }
-          },
-          "com_github_google_ksp": {
-            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
-            "attributes": {
-              "urls": [
-                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
-              ],
-              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
-              "strip_version": "1.9.23-1.0.20"
-            }
-          },
-          "com_github_pinterest_ktlint": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
-            "attributes": {
-              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
-              "urls": [
-                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
-              ],
-              "executable": true
-            }
-          },
-          "rules_android": {
-            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
-            "attributes": {
-              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-              "strip_prefix": "rules_android-0.1.1",
-              "urls": [
-                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
-              ]
-            }
-          }
-        },
-        "recordedRepoMappingEntries": [
-          [
-            "rules_kotlin+",
-            "bazel_tools",
-            "bazel_tools"
-          ]
-        ]
-      }
-    }
-  }
+  "moduleExtensions": {}
 }

--- a/bazelrc-preset.bzl
+++ b/bazelrc-preset.bzl
@@ -37,9 +37,10 @@ def _format_boolean_flag(flag, meta):
 
 def _generate_preset_flag(content, flag, meta):
     if not getattr(meta, "if_bazel_version", True):
-        return  # Flag does not apply to the version of Bazel currently running
+        return content  # Flag does not apply to the version of Bazel currently running
     content.add_all(meta.description.strip().split("\n"), format_each = "# %s", map_each = _strip)
     content.add(_format_flag(flag, meta))
+    return content
 
 def _generate_preset(ctx):
     content = ctx.actions.args().set_param_file_format("multiline")
@@ -56,7 +57,7 @@ def _generate_preset(ctx):
         if type(meta) != type([]):
             meta = [meta]
         for meta_item in meta:
-            _generate_preset_flag(content, flag, meta_item)
+            content = _generate_preset_flag(content, flag, meta_item)
         content.add("")
     ctx.actions.write(ctx.outputs.out, content)
 

--- a/bazelrc-preset.bzl
+++ b/bazelrc-preset.bzl
@@ -37,15 +37,9 @@ def _format_boolean_flag(flag, meta):
 
 def _generate_preset_flag(content, flag, meta):
     if not getattr(meta, "if_bazel_version", True):
-        return content  # Flag does not apply to the version of Bazel currently running
+        return  # Flag does not apply to the version of Bazel currently running
     content.add_all(meta.description.strip().split("\n"), format_each = "# %s", map_each = _strip)
     content.add(_format_flag(flag, meta))
-    content.add_all([
-        "#",
-        "# Docs: https://registry.build/flag/bazel@{}?filter={}".format(version, flag),
-        "",
-    ])
-    return content
 
 def _generate_preset(ctx):
     content = ctx.actions.args().set_param_file_format("multiline")
@@ -57,11 +51,13 @@ def _generate_preset(ctx):
     content.add("")
 
     for flag, meta in FLAGS.items():
-        if type(meta) == type([]):
-            for meta_item in meta:
-                content = _generate_preset_flag(content, flag, meta_item)
-        else:
-            content = _generate_preset_flag(content, flag, meta)
+        content.add("# {}".format(flag))
+        content.add("# Docs: https://registry.build/flag/bazel@{}?filter={}".format(version, flag))
+        if type(meta) != type([]):
+            meta = [meta]
+        for meta_item in meta:
+            _generate_preset_flag(content, flag, meta_item)
+        content.add("")
     ctx.actions.write(ctx.outputs.out, content)
 
 generate_preset = rule(


### PR DESCRIPTION
Only list the Docs link once for flags that have multiple settings, for example on Bazel 7.x now looks like

```

# build_runfile_links
# Docs: https://registry.build/flag/bazel@7.6.1?filter=build_runfile_links
# Avoid creating a runfiles tree for binaries or tests until it is needed.
# See https://github.com/bazelbuild/bazel/issues/6627
# This may break local workflows that `build` a binary target, then run the resulting program outside of `bazel run`.
# In those cases, the script will need to call `bazel build --build_runfile_links //my/binary:target` and then execute the resulting program.
common --nobuild_runfile_links
# See https://github.com/bazelbuild/bazel/issues/20577
coverage --build_runfile_links

```