### PR TITLE
ci: don't print info on passing tests

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -188,4 +188,13 @@ FLAGS = {
         The terminal width in columns. Configure this to override the default value based on what your CI system renders.
         """,
     ),
+    "test_summary": struct(
+        command = "test:ci",
+        default = "terse",
+        description = """\
+        The default test_summary ("short") prints a result for every test target that was executed.
+        In a large repo this amounts to hundreds of lines of additional log output when testing a broad wildcard pattern like //...
+        This value means to print information only about unsuccessful tests that were run.
+        """,
+    ),
 }


### PR DESCRIPTION
Makes CI logs spammy.

Some slack context: https://aspect-build.slack.com/archives/C08H3SGQ1U2/p1750856056618979?thread_ts=1750806762.130319&cid=C08H3SGQ1U2