### PR TITLE
fix(bazel 6): don't enable BwoB

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -191,6 +191,7 @@ FLAGS = {
     ),
     "remote_download_toplevel": struct(
         command = "common:ci",
+        if_bazel_version = ge("7.0.0rc1"),
         default = True,
         description = """\
         On CI, only download remote outputs of top level targets to the local machine.


### PR DESCRIPTION
Build without the bytes became stable only in Bazel 7 and shouldn't be recommended on CI for older versions.