### PR TITLE
fix: the macro reads a new strict flag

### DIFF
--- a/.github/workflows/delta.yaml
+++ b/.github/workflows/delta.yaml
@@ -27,13 +27,16 @@ jobs:
       - name: Opt-in to strict flags
         if: matrix.strict
         run: |
-          sed -i 's/strict = False/strict = True/' tests/BUILD
+          sudo tee -a /etc/bazel.bazelrc >/dev/null <<EOF
+          common --@bazelrc-preset.bzl//:strict
+          EOF
       - name: Current output
         id: new
         run: |
           bazel build tests:preset
           cat bazel-bin/tests/preset.bazelrc | tee /tmp/new
-          git restore MODULE.bazel.lock tests/BUILD
+          # Avoid problems with later bazel calls under --lockfile_mode=error
+          git restore MODULE.bazel.lock
         env:
           USE_BAZEL_VERSION: ${{ matrix.bazel_version }}
       - name: Disallow trailing whitespace

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,14 @@
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+bool_flag(
+    name = "strict",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "strict.true",
+    flag_values = {
+        ":strict": "true",
+    },
+)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Bazelisk provides [extra command-line options](https://github.com/bazelbuild/baz
 2. For flags that don't work, either
   - disable them by explicitly setting the value in your .bazelrc
   - fix the issues they report
-3. Turn on `strict=True` on the `bazelrc_preset` rule. This is a superset of running `bazelisk --strict build ...`
+3. Add `common --@bazelrc-preset.bzl//:strict` to the project `.bazelrc`. This is a superset of running `bazelisk --strict build ...`
 
 ## References and Credits
 

--- a/bazelrc-preset.bzl
+++ b/bazelrc-preset.bzl
@@ -93,21 +93,23 @@ generate_preset = rule(
     },
 )
 
-def bazelrc_preset(name, out_file = None, **kwargs):
+def bazelrc_preset(name, out_file = None):
     """
     Creates a bazelrc preset file.
 
     Args:
         name: The name of the preset.
         out_file: The file to write the preset to. If not provided, the preset will be written to `{name}.bazelrc`.
-        **kwargs: additional named parameters to generate_preset
     """
     if lt("6.0.0"):
         fail("bazelrc_preset requires Bazel 6 or later. You are running Bazel {}".format(version))
     generate_preset(
         name = name,
         out = "_{}.bazelrc".format(name),
-        **kwargs
+        strict = select({
+            Label("//:strict.true"): True,
+            "//conditions:default": False,
+        }),
     )
     if not out_file:
         out_file = "{}.bazelrc".format(name)

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -4,7 +4,10 @@ load("//:bazelrc-preset.bzl", "generate_preset")
 generate_preset(
     name = "preset",
     out = "preset.bazelrc",
-    strict = False,
+    strict = select({
+        "//:strict.true": True,
+        "//conditions:default": False,
+    }),
 )
 
 # To inspect the changes to presets when contributors send a PR


### PR DESCRIPTION
This makes it easier for a system bazelrc to turn on strict mode, or experiment with strictness for a single build without code changes

Fixes #49 