### PR TITLE
Fix flag override generation

### DIFF
--- a/bazelrc-preset.bzl
+++ b/bazelrc-preset.bzl
@@ -67,17 +67,11 @@ def _generate_preset(ctx):
         if type(meta) != type([]):
             meta = [meta]
         _verify_command_overrides(meta)
-        flag_appears = False
         for meta_item in meta:
             content_with_flag = _generate_preset_flag(content, flag, meta_item)
             if content_with_flag:
                 content = content_with_flag
-                flag_appears = True
-                break
-        if flag_appears:
-            content.add_all([
-                "# Docs: https://registry.build/flag/bazel@{}?filter={}".format(version, flag),
-            ])
+                content.add("# Docs: https://registry.build/flag/bazel@{}?filter={}".format(version, flag))
     ctx.actions.write(ctx.outputs.out, content)
 
 generate_preset = rule(


### PR DESCRIPTION
https://github.com/bazel-contrib/bazelrc-preset.bzl/commit/9db425c8893d02f6c3f266ae715d041921a5a25b broke the flag overrides so that they were no longer created.

The most simple fix would have been to only remove the `break`, but formatting wise this looks better and we get the docs link directly under the flag. Having the duplication of the docs link is acceptable to me.