### PR TITLE
Add incompatible_exclusive_test_sandboxed for bazel 6

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -430,6 +430,16 @@ MIGRATIONS = {
         See https://github.com/bazelbuild/bazel/issues/17032
         """,
     ),
+    "incompatible_exclusive_test_sandboxed": struct(
+        default = True,
+        if_bazel_version = ge_same_major("6.0.0"),
+        description = """\
+         Allow exclusive tests to run in the sandbox.
+         Fixes a bug where Bazel doesn't enable sandboxing for tests with `tags=["exclusive"]`.
+
+        See https://github.com/bazelbuild/bazel/issues/16871
+        """,
+    ),
     "incompatible_repo_env_ignores_action_env": struct(
         default = True,
         if_bazel_version = ge_same_major("8.3.0"),


### PR DESCRIPTION
We don't have
https://github.com/bazel-contrib/bazel-lib/blob/bbdbcf9b9e4b6fe7e81efecf83e820a8b0332fb6/.aspect/bazelrc/correctness.bazelrc#L33C3-L36
yet which was flipped with Bazel 7, so adding for Bazel 6.
