### PR TITLE
feat: Add preset test macro

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -152,5 +152,70 @@
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
   },
   "selectedYankedVersions": {},
-  "moduleExtensions": {}
+  "moduleExtensions": {
+    "@@rules_kotlin+//src/main/starlark/core/repositories:bzlmod_setup.bzl%rules_kotlin_extensions": {
+      "general": {
+        "bzlTransitiveDigest": "hUTp2w+RUVdL7ma5esCXZJAFnX7vLbVfLd7FwnQI6bU=",
+        "usagesDigest": "QI2z8ZUR+mqtbwsf2fLqYdJAkPOHdOV+tF2yVAUgRzw=",
+        "recordedFileInputs": {},
+        "recordedDirentsInputs": {},
+        "envVariables": {},
+        "generatedRepoSpecs": {
+          "com_github_jetbrains_kotlin_git": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_compiler_git_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/JetBrains/kotlin/releases/download/v1.9.23/kotlin-compiler-1.9.23.zip"
+              ],
+              "sha256": "93137d3aab9afa9b27cb06a824c2324195c6b6f6179d8a8653f440f5bd58be88"
+            }
+          },
+          "com_github_jetbrains_kotlin": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:compiler.bzl%kotlin_capabilities_repository",
+            "attributes": {
+              "git_repository_name": "com_github_jetbrains_kotlin_git",
+              "compiler_version": "1.9.23"
+            }
+          },
+          "com_github_google_ksp": {
+            "repoRuleId": "@@rules_kotlin+//src/main/starlark/core/repositories:ksp.bzl%ksp_compiler_plugin_repository",
+            "attributes": {
+              "urls": [
+                "https://github.com/google/ksp/releases/download/1.9.23-1.0.20/artifacts.zip"
+              ],
+              "sha256": "ee0618755913ef7fd6511288a232e8fad24838b9af6ea73972a76e81053c8c2d",
+              "strip_version": "1.9.23-1.0.20"
+            }
+          },
+          "com_github_pinterest_ktlint": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_file",
+            "attributes": {
+              "sha256": "01b2e0ef893383a50dbeb13970fe7fa3be36ca3e83259e01649945b09d736985",
+              "urls": [
+                "https://github.com/pinterest/ktlint/releases/download/1.3.0/ktlint"
+              ],
+              "executable": true
+            }
+          },
+          "rules_android": {
+            "repoRuleId": "@@bazel_tools//tools/build_defs/repo:http.bzl%http_archive",
+            "attributes": {
+              "sha256": "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
+              "strip_prefix": "rules_android-0.1.1",
+              "urls": [
+                "https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"
+              ]
+            }
+          }
+        },
+        "recordedRepoMappingEntries": [
+          [
+            "rules_kotlin+",
+            "bazel_tools",
+            "bazel_tools"
+          ]
+        ]
+      }
+    }
+  }
 }

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,6 +1,6 @@
 load("@aspect_bazel_lib//lib:testing.bzl", "assert_contains")
 load("@bazel_skylib//rules:native_binary.bzl", "native_test")
-load("//:bazelrc-preset.bzl", "bazelrc_preset")
+load("//:bazelrc-preset.bzl", "bazelrc_preset", "bazelrc_preset_test")
 load(":extra_test_presets.bzl", "EXTRA_TEST_PRESETS")
 
 bazelrc_preset(
@@ -40,4 +40,30 @@ assert_contains(
     name = "test_with_extra_presets_as_dict",
     actual = ":preset_with_extra_presets",
     expected = "common:bar --extra_preset_as_dict",
+)
+
+bazelrc_preset_test(name = "test_default_preset")
+
+bazelrc_preset_test(
+    name = "test_strict_preset",
+    strict = True,
+)
+
+bazelrc_preset_test(
+    name = "test_preset_with_extra_presets",
+    extra_presets = EXTRA_TEST_PRESETS | {
+        "extra_preset_as_dict": {
+            "command": "common:bar",
+            "default": True,
+            "description": """\
+            Extra preset that can be provided by the user.
+            """,
+        },
+    },
+)
+
+bazelrc_preset_test(
+    name = "test_strict_preset_with_extra_presets",
+    extra_presets = EXTRA_TEST_PRESETS,
+    strict = True,
 )


### PR DESCRIPTION
https://github.com/aspect-build/toolchains_protoc/pull/84 is the first project to define its own presets that can be used by this project to be included in the preset generation.

This PR adds a test macro so that other projects such as https://github.com/aspect-build/toolchains_protoc can test that there flag structure is correct.