### PR TITLE
feat: allow releasing from GH UI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
     secrets:
-      publish_token:
+      BCR_PUBLISH_TOKEN:
         required: true
   # In case of problems, let release engineers retry by manually dispatching
   # the workflow from the GitHub UI
@@ -32,4 +32,4 @@ jobs:
       id-token: write
     secrets:
       # Necessary to push to the BCR fork, and to open a pull request against a registry
-      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
     secrets:
-      publish_token:
+      BCR_PUBLISH_TOKEN:
         required: true
   # Or, developers can manually push a tag from their clone
   push:
@@ -30,4 +30,4 @@ jobs:
     with:
       tag_name: ${{ inputs.tag_name || github.ref_name }}
     secrets:
-      publish_token: ${{ secrets.publish_token || secrets.BCR_PUBLISH_TOKEN }}
+      BCR_PUBLISH_TOKEN: ${{ secrets.BCR_PUBLISH_TOKEN }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -1,0 +1,42 @@
+# Tag a new release
+# This is easier than having to run manual `git` operations on a local clone.
+# It also runs on a schedule so we don't leave commits unreleased indefinitely
+# (avoiding users having to ping "hey could someone cut a release").
+name: Tag a Release
+on:
+  # Allow devs to tag manually through the GitHub UI.
+  # For example after landing a fix that customers are waiting for.
+  workflow_dispatch:
+  # Run at 4PM UTC (9AM PST) on the 3rd and 18th of each month.
+  # This is a trade-off between making too many releases,
+  # which overwhelms BCR maintainers and over-notifies users,
+  # and releasing too infrequently which delays delivery of bugfixes and features.
+  schedule:
+    - cron: "0 16 3,18 * *"
+jobs:
+  tag:
+    permissions:
+      contents: write # allow create tag
+    runs-on: ubuntu-latest
+    outputs:
+      new-tag: ${{ steps.ccv.outputs.new-tag }}
+      new-tag-version: ${{steps.ccv.outputs.new-tag-version}}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need enough history to find the prior release tag
+          fetch-depth: 0
+      - name: Bump tag if necessary
+        id: ccv
+        uses: smlx/ccv@7318e2f25a52dcd550e75384b84983973251a1f8 # v0.10.0
+  release:
+    needs: tag
+    uses: ./.github/workflows/release.yaml
+    with:
+      tag_name: ${{ needs.tag.outputs.new-tag-version }}
+    if: needs.tag.outputs.new-tag == 'true' && needs.tag.outputs.new-tag-version-type != 'major'
+    secrets: inherit
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write


### PR DESCRIPTION
It's easy to clone the repo and tag on the command-line, but it's error-prone - you might fetch the wrong remote, then apply a tag you think is at HEAD of origin/main but is actually stale. I've done that!

Instead this automation lets us click a button on GitHub and guaranteed to release the right thing. Also adds a cron so we don't accidentally go several weeks without a release. It only makes one if there are fixes or features.

Note, it expects our commit history has semantic commits