### PR TITLE
docs: Move strict option to migration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,55 @@ Read [the Bazel bazelrc documentation](https://bazel.build/run/bazelrc).
 ## Install
 
 1. Add `bazelrc-preset.bzl` to your `MODULE.bazel` file.
-2. Call it from a BUILD file, for example in `tools/BUILD`:
+2. Call it from a `BUILD` file, for example in `tools/BUILD`:
+
+    ```starlark
+    load("@bazelrc-preset.bzl", "bazelrc_preset")
+
+    bazelrc_preset(
+        name = "preset",
+    )
+    ```
+
+3. Create the preset by running `bazel run //tools:preset.update`.
+Note that you don't need to remember the command.
+A test target `preset.update_test` is also created, which prints the command if the file is missing or has outdated contents.
+
+4. Import it into your project's `/.bazelrc` file.
+We suggest you add it at the top, so that project-specific flags may override values.
+See https://bazel.build/configure/best-practices#bazelrc-file
+
+    You can copy this template to get started:
+
+    ```
+    ########################
+    # Import bazelrc presets
+    import %workspace%/tools/preset.bazelrc
+    ...
+
+    ########################
+    # Project-specific flags
+    # This is also a place to override settings from the presets
+
+    ...
+
+    ########################
+    # User preferences
+    # Load any settings & overrides specific to the current user from `user.bazelrc`.
+    # This file should appear in `.gitignore` so that settings are not shared with team members.
+    # This should be last statement in this config so the user configuration overrides anything above.
+    try-import %workspace%/user.bazelrc
+    ```
+
+5. Some flags are enabled only under a given config.
+   For example, many flags apply only when running on CI.
+   Configure your CI system to always pass `--config=ci` when running Bazel (for example, put it in the system bazelrc on CI runner machines).
+
+## Migrating to stricter flags
+
+Bazel major releases include flag-flips.
+We provide a strict preset that includes all flags that will be flipped in the upcoming major release.
+To opt-in to these flags, you can set the `strict` attribute to `True` when calling `bazelrc_preset`.
 
 ```starlark
 load("@bazelrc-preset.bzl", "bazelrc_preset")
@@ -32,45 +80,8 @@ bazelrc_preset(
 )
 ```
 
-3. Create the preset by running `bazel run //tools:preset.update`.
-Note that you don't need to remember the command.
-A test target `preset.update_test` is also created, which prints the command if the file is missing or has outdated contents.
-
-4. Import it into your project's `/.bazelrc` file.
-We suggest you add it at the top, so that project-specific flags may override values.
-See https://bazel.build/configure/best-practices#bazelrc-file
-
-You can copy this template to get started:
-
-```
-########################
-# Import bazelrc presets
-import %workspace%/tools/preset.bazelrc
-...
-
-########################
-# Project-specific flags
-# This is also a place to override settings from the presets
-
-...
-
-########################
-# User preferences
-# Load any settings & overrides specific to the current user from `user.bazelrc`.
-# This file should appear in `.gitignore` so that settings are not shared with team members.
-# This should be last statement in this config so the user configuration overrides anything above.
-try-import %workspace%/user.bazelrc
-```
-
-5. Some flags are enabled only under a given config.
-   For example, many flags apply only when running on CI.
-   Configure your CI system to always pass `--config=ci` when running Bazel (for example, put it in the system bazelrc on CI runner machines).
-
-## Migrating to stricter flags
-
-Bazel major releases include flag-flips.
-
-Bazelisk provides [extra command-line options](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#other-features) to migrate to stricter flags. A common migration pattern is:
+Bazelisk provides [extra command-line options](https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#other-features) to migrate to stricter flags.
+A common migration pattern is:
 
 1. Run `bazelisk --migrate build --nobuild //...` to try upgrading new strict flags.
 2. For flags that don't work, either
@@ -85,23 +96,23 @@ If your project defines specific flags that users should set, you can define the
 1. Define your own flags using the same data structure as [`flags.bzl`](flags.bzl) or [`tests/extra_test_presets.bzl`](tests/extra_test_presets.bzl).
 2. Add a `bazelrc_preset_test` to make sure your presets format is correct.
 
-```starlark
-bazelrc_preset_test(
-    name = "test_project_preset",
-    extra_presets = CUSTOM_PROJECT_PRESETS,
-)
-```
+    ```starlark
+    bazelrc_preset_test(
+        name = "test_project_preset",
+        extra_presets = CUSTOM_PROJECT_PRESETS,
+    )
+    ```
 
 3. Any user of your project can now consume your presets and add them to their presets
 
-```starlark
-load("@my_project//:flags.bzl", "CUSTOM_PROJECT_PRESETS")
+    ```starlark
+    load("@my_project//:flags.bzl", "CUSTOM_PROJECT_PRESETS")
 
-bazelrc_preset(
-    name = "preset",
-    extra_presets = CUSTOM_PROJECT_PRESETS
-)
-```
+    bazelrc_preset(
+        name = "preset",
+        extra_presets = CUSTOM_PROJECT_PRESETS
+    )
+    ```
 
 ## References and Credits
 


### PR DESCRIPTION
#77 shows that https://github.com/bazel-contrib/bazelrc-preset.bzl/blob/0b4df86a3af7e7ca035139139796dff8e243e115/README.md#L31 can cause some confusion. We should move this down into the migration section to have a simple default.

I also fix more indentation of codeblocks to be aligned with the enumeration sections.