### PR TITLE
make readme more precise

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Read [the Bazel bazelrc documentation](https://bazel.build/run/bazelrc).
 ## Install
 
 1. Add `bazelrc-preset.bzl` to your `MODULE.bazel` file.
+    ```starlark
+    bazel_dep(name = "bazelrc-preset.bzl", version = "1.3.0")
+    ```
+    
 2. Call it from a `BUILD` file, for example in `tools/BUILD`:
 
     ```starlark


### PR DESCRIPTION
There is also a file in the repository called `bazelrc-preset.bzl`. The text can also be understood to append the content of the file to your own `MODULE.bazel`.

Especially new users may be a little less confused when it is stated explicitly using an example.