### PR TITLE
chore: remove source directory watching on Bazel 9

### DIFF
--- a/flags.bzl
+++ b/flags.bzl
@@ -164,6 +164,7 @@ FLAGS = {
     ),
     "host_jvm_args": struct(
         default = "-DBAZEL_TRACK_SOURCE_DIRECTORIES=1",
+        if_bazel_version = lt("9.0.0"),
         command = "startup",
         description = """\
         Allow the Bazel server to check directory sources for changes. Ensures that the Bazel server


### PR DESCRIPTION
It's fixed, per the release notes:

> The contents of source directories are now tracked for invalidation. Using glob or explicit lists of files to consume source directories is still strongly preferred, but there may be cases in which this isn't feasible (e.g. file names that aren't valid labels).